### PR TITLE
Add support for optional frequency value in pacing calculation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,39 @@ paced.calculate
   ]
 =end
 
+# Optionally if we want to include the frequency of the discipline in the pacing output we can
+# pass in the optional param `show_frequency`. This value defaults to false.
+
+paced = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, mode: :liberal, summer_holidays: summer_holidays, state: state, show_frequency: true)
+paced.calculate
+
+# Below is the output we will get when in strict mode and also showing the frequency in the pacing output.
+=begin
+=> [
+    {
+      discipline: 'Speech Therapy',
+      remaining_visits: 0,
+      used_visits: 7,
+      expected_visits_at_date: 3,
+      reset_date: '05-11-2022',
+      pace: 4,
+      pace_indicator: "🐇",
+      pace_suggestion: "less than once per week".
+      frequency: "6Mx30ST"
+    }, {
+      discipline: 'Physical Therapy',
+      remaining_visits: 0,
+      expected_visits_at_date: 3,
+      used_visits: 7,
+      reset_date: '05-11-2022',
+      pace: 4,
+      pace_indicator: "🐇",
+      pace_suggestion: "less than once per week",
+      frequency: "6Mx30PT"
+    }
+  ]
+=end
+
 paced.interval # Return current interval start and end dates
 
 # Below is the result you will get

--- a/lib/pacing/pacer.rb
+++ b/lib/pacing/pacer.rb
@@ -4,13 +4,14 @@ require 'holidays'
 module Pacing
   class Pacer
     COMMON_YEAR_DAYS_IN_MONTH = [nil, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    attr_reader :school_plan, :date, :non_business_days, :state, :mode, :interval, :summer_holidays
+    attr_reader :school_plan, :date, :non_business_days, :state, :mode, :interval, :summer_holidays, :show_frequency
 
-    def initialize(school_plan:, date:, non_business_days:, state: :us_tn, mode: :liberal, summer_holidays: [])
+    def initialize(school_plan:, date:, non_business_days:, state: :us_tn, mode: :liberal, summer_holidays: [], show_frequency: false)
       @school_plan = school_plan
       @non_business_days = non_business_days
       @date = date
       @state = state
+      @show_frequency = show_frequency
       @mode = [:strict, :liberal].include?(mode) ? mode : :liberal
 
       Pacing::Error.new(school_plan: school_plan, date: date, non_business_days: non_business_days, state: state, mode: mode, summer_holidays: summer_holidays)
@@ -86,12 +87,21 @@ module Pacing
         discipline[:pace_indicator] = pace_indicator(discipline[:pace])
         discipline[:pace_suggestion] = readable_suggestion(rate: discipline[:suggested_rate])
 
+        if show_frequency
+          discipline[:frequency] = discipline_frequency(service)
+        end
+
         discipline.delete(:suggested_rate)
 
         discipline
       end
 
       services
+    end
+
+    # discipline iep frequency
+    def discipline_frequency(service)
+      service[:frequency].to_s + service[:interval][0].gsub(/(per)|p/i, "").strip.upcase + "x" + service[:time_per_session_in_minutes].to_s + service[:type_of_service][0].upcase + "T"
     end
 
     # get a spreadout of visit dates over an interval by using simple proportion.

--- a/spec/pacing_spec.rb
+++ b/spec/pacing_spec.rb
@@ -5183,3 +5183,53 @@ RSpec.describe Pacing::Pacer do
     end
   end
 end
+
+describe "should include frequency in the output if show frequency is true" do
+  it "should correctly parse the pacing for patient 4558" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"02-23-2022", :end_date=>"02-23-2023", :type_of_service=>"Speech Therapy", :frequency=>12, :interval=>"monthly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>3, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"monthly"}, {:school_plan_type=>"IEP", :start_date=>"05-19-2022", :end_date=>"11-01-2022", :type_of_service=>"Language Therapy", :frequency=>3, :interval=>"weekly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>0, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"weekly"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>22, :used_visits=>3, :pace=>-10, :pace_indicator=>"🐢", :pace_suggestion=>"once a day", :expected_visits_at_date=>13, :reset_date=>"11-01-2022", :frequency=>"25Mx20ST"}])
+  end
+
+  it "should correctly parse the pacing for patient 4559" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"10-27-2021", :end_date=>"10-27-2022", :type_of_service=>"Speech Therapy", :frequency=>8, :interval=>"monthly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>1, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"monthly"}, {:school_plan_type=>"IEP", :start_date=>"10-27-2021", :end_date=>"10-27-2022", :type_of_service=>"Speech Therapy", :frequency=>1, :interval=>"weekly", :time_per_session_in_minutes=>45, :completed_visits_for_current_interval=>0, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"weekly"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>11, :used_visits=>1, :pace=>-5, :pace_indicator=>"🐢", :pace_suggestion=>"about once every other day", :expected_visits_at_date=>6, :reset_date=>"11-01-2022", :frequency=>"12Mx45ST"}])
+  end
+
+  it "should also accept 'Language' as a type of service 4560" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"05-23-2022", :end_date=>"05-23-2023", :type_of_service=>"Speech Therapy", :frequency=>6, :interval=>"monthly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>4, :extra_sessions_allowable=>1, :interval_for_extra_sessions_allowable=>"monthly"}, {:school_plan_type=>"IEP", :start_date=>"05-23-2022", :end_date=>"05-23-2023", :type_of_service=>"Language", :frequency=>6, :interval=>"monthly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>4, :extra_sessions_allowable=>1, :interval_for_extra_sessions_allowable=>"monthly"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>10, :used_visits=>4, :pace=>-2, :pace_indicator=>"🐢", :pace_suggestion=>"about once every other day", :expected_visits_at_date=>6, :reset_date=>"11-01-2022", :frequency=>"12Mx20ST"}])
+  end
+
+  it "should correctly parse the pacing for patient 4561" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"12-03-2021", :end_date=>"12-03-2022", :type_of_service=>"Speech and language", :frequency=>12, :interval=>"monthly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>4, :extra_sessions_allowable=>1, :interval_for_extra_sessions_allowable=>"monthly"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>9, :used_visits=>4, :pace=>-2, :pace_indicator=>"🐢", :pace_suggestion=>"about once every other day", :expected_visits_at_date=>6, :reset_date=>"11-01-2022", :frequency=>"12Mx20ST"}])
+  end
+
+  it "should correctly parse the pacing for patient 4562" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"09-27-2022", :end_date=>"09-27-2023", :type_of_service=>"Language Therapy", :frequency=>30, :interval=>"yearly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>4, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"yearly"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>26, :used_visits=>4, :pace=>2, :pace_indicator=>"🐇", :pace_suggestion=>"less than once per week", :expected_visits_at_date=>2, :reset_date=>"09-27-2023", :frequency=>"30Yx20ST"}])
+  end
+
+  it "should correctly parse the pacing for patient 4563" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"11-03-2021", :end_date=>"11-03-2022", :type_of_service=>"Speech Therapy", :frequency=>1, :interval=>"weekly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>0, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"weekly"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>1, :used_visits=>0, :pace=>0, :pace_indicator=>"😁", :pace_suggestion=>"once a week", :expected_visits_at_date=>0, :reset_date=>"10-24-2022", :frequency=>"1Wx20ST"}])
+  end
+end


### PR DESCRIPTION
Pass the `show_frequency: true` option to include frequency in the pacing output.

Why?

We normalize frequencies in pacing and aggregate required visit times in pacing calculation before calculating the pacing. This information is necessary to determine the IEP frequency. Including it as an optional field in pacing output will make it so that this calculation is done in one place and not several places in the codebase. It will also save us some additional queries that would otherwise have been required when showing the cached pacing values in an organization's caseload.