### PR TITLE
Improve date range checker

### DIFF
--- a/lib/pacing/error.rb
+++ b/lib/pacing/error.rb
@@ -53,7 +53,7 @@ module Pacing
 
       begin
         @school_plan[:school_plan_services].each do |school_plan_service|
-          if (parse_date(school_plan_service[:start_date]) < parse_date(@date) && parse_date(@date) < parse_date(school_plan_service[:end_date]))
+          if (parse_date(school_plan_service[:start_date]) <= parse_date(@date) && parse_date(@date) <= parse_date(school_plan_service[:end_date]))
             valid_range_or_exceptions = true
           end
         end
@@ -72,4 +72,3 @@ module Pacing
     end
   end
 end
-

--- a/lib/pacing/normalizer.rb
+++ b/lib/pacing/normalizer.rb
@@ -32,7 +32,7 @@ module Pacing
       discipline_services = services.filter do |service|
         ["pragmatic language", "speech and language", "language", "speech", "language therapy", "speech therapy", "speech and language therapy", "speech language therapy"].include?(service[:type_of_service].downcase)
       end
-      
+
       return {} if discipline_services.empty?
 
       discipline_services = normalize_to_monthly_frequency(discipline_services)
@@ -57,7 +57,7 @@ module Pacing
       discipline_services = services.filter do |service|
         ["occupation therapy", "occupational therapy", "occupation"].include?(service[:type_of_service].downcase)
       end
-      
+
       return {} if discipline_services.empty?
 
       discipline_services = normalize_to_monthly_frequency(discipline_services)
@@ -82,7 +82,7 @@ module Pacing
       discipline_services = services.filter do |service|
         ["physical therapy", "physical"].include?(service[:type_of_service].downcase)
       end
-      
+
       return {} if discipline_services.empty?
 
       discipline_services = normalize_to_monthly_frequency(discipline_services)
@@ -107,7 +107,7 @@ module Pacing
       discipline_services = services.filter do |service|
         ["feeding therapy", "feeding"].include?(service[:type_of_service].downcase)
       end
-      
+
       return {} if discipline_services.empty?
 
       discipline_services = normalize_to_monthly_frequency(discipline_services)
@@ -155,8 +155,11 @@ module Pacing
       # average business days for each interval
       interval_average_days = {
         "weekly" => 5,
+        "per week" => 5,
         "monthly" => 22,
-        "yearly" => 210 # take away average holidays period with is 2.5 months
+        "per month" => 22,
+        "yearly" => 210,
+        "per year" => 210 # take away average holidays period with is 2.5 months
       }
 
       return services if same_interval(services)
@@ -164,7 +167,7 @@ module Pacing
       services.map do |service|
         if !(service[:interval] == "monthly")
           # weekly(5 days) = frequency # weekly
-          # monthly(20 days) = frequency * monthly 
+          # monthly(20 days) = frequency * monthly
           # yearly(200 days)
 
           f = service[:frequency]
@@ -207,4 +210,3 @@ module Pacing
     end
   end
 end
-

--- a/lib/pacing/pacer.rb
+++ b/lib/pacing/pacer.rb
@@ -101,7 +101,7 @@ module Pacing
 
     # discipline iep frequency
     def discipline_frequency(service)
-      service[:frequency].to_s + service[:interval][0].gsub(/(per)|p/i, "").strip.upcase + "x" + service[:time_per_session_in_minutes].to_s + service[:type_of_service][0].upcase + "T"
+      service[:frequency].to_s + service[:interval].gsub(/(per)|p/i, "").strip[0].upcase + "x" + service[:time_per_session_in_minutes].to_s + service[:type_of_service][0].upcase + "T"
     end
 
     # get a spreadout of visit dates over an interval by using simple proportion.
@@ -348,6 +348,6 @@ module Pacing
       holidays_start += 1 until holidays_start.wday == 1
 
       [holidays_start, holidays_end]
-    end 
+    end
   end
 end

--- a/spec/pacing_spec.rb
+++ b/spec/pacing_spec.rb
@@ -5232,4 +5232,30 @@ describe "should include frequency in the output if show frequency is true" do
     results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
     expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>1, :used_visits=>0, :pace=>0, :pace_indicator=>"😁", :pace_suggestion=>"once a week", :expected_visits_at_date=>0, :reset_date=>"10-24-2022", :frequency=>"1Wx20ST"}])
   end
+
+  it "should correctly parse the pacing for patient 4564 when start_date is same as date" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"01-09-2023", :end_date=>"03-30-2023", :type_of_service=>"Speech Therapy", :frequency=>1, :interval=>"weekly", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>0, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"weekly"}]}
+    date = "01-09-2023"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>1, :used_visits=>0, :pace=>0, :pace_indicator=>"😁", :pace_suggestion=>"once a week", :expected_visits_at_date=>0, :reset_date=>"01-16-2023", :frequency=>"1Wx20ST"}])
+  end
+end
+
+describe "should calculate pacing correctly when interval starts with 'per month, per week, and per year'" do
+  it "should correctly parse the pacing for patient 4565" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"02-23-2022", :end_date=>"02-23-2023", :type_of_service=>"Speech Therapy", :frequency=>12, :interval=>"per month", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>3, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"per month"}, {:school_plan_type=>"IEP", :start_date=>"05-19-2022", :end_date=>"11-01-2022", :type_of_service=>"Language Therapy", :frequency=>3, :interval=>"per week", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>0, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"per week"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>22, :used_visits=>3, :pace=>-10, :pace_indicator=>"🐢", :pace_suggestion=>"once a day", :expected_visits_at_date=>13, :reset_date=>"11-01-2022", :frequency=>"25Mx20ST"}])
+  end
+
+  it "should correctly parse the pacing for patient 4566" do
+    school_plan = {:school_plan_services=>[{:school_plan_type=>"IEP", :start_date=>"09-27-2022", :end_date=>"09-27-2023", :type_of_service=>"Language Therapy", :frequency=>30, :interval=>"per year", :time_per_session_in_minutes=>20, :completed_visits_for_current_interval=>4, :extra_sessions_allowable=>0, :interval_for_extra_sessions_allowable=>"per year"}]}
+    date = "10-17-2022"
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
+    expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>26, :used_visits=>4, :pace=>2, :pace_indicator=>"🐇", :pace_suggestion=>"less than once per week", :expected_visits_at_date=>2, :reset_date=>"09-27-2023", :frequency=>"30Yx20ST"}])
+  end
 end


### PR DESCRIPTION
- Allow the date range checker to support start_date or end_date being the same as the pace calculation date.
- Improve support for "per week" format intervals
- Add specs for all the above scenarios
