### PR TITLE
Skip services with unsupported intervals instead of crashing

### DIFF
--- a/lib/pacing/normalizer.rb
+++ b/lib/pacing/normalizer.rb
@@ -165,7 +165,7 @@ module Pacing
       return services if same_interval(services)
 
       services.map do |service|
-        if !(service[:interval] == "monthly")
+        if !(service[:interval] == "monthly") && interval_average_days.key?(service[:interval])
           # weekly(5 days) = frequency # weekly
           # monthly(20 days) = frequency * monthly
           # yearly(200 days)

--- a/lib/pacing/pacer.rb
+++ b/lib/pacing/pacer.rb
@@ -4,6 +4,7 @@ require 'holidays'
 module Pacing
   class Pacer
     COMMON_YEAR_DAYS_IN_MONTH = [nil, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    SUPPORTED_INTERVALS = %w[monthly per\ month weekly per\ week yearly per\ year].freeze
     attr_reader :school_plan, :date, :non_business_days, :state, :mode, :interval, :summer_holidays, :show_frequency
 
     def initialize(school_plan:, date:, non_business_days:, state: :us_tn, mode: :liberal, summer_holidays: [], show_frequency: false)
@@ -22,6 +23,8 @@ module Pacing
     def interval
       # filter out services that haven't started or whose time is passed
       services = @school_plan[:school_plan_services].filter do |school_plan_service|
+        next false unless SUPPORTED_INTERVALS.include?(school_plan_service[:interval])
+
         within = true
         if !(parse_date(school_plan_service[:start_date]) <= parse_date(@date) && parse_date(@date) <= parse_date(school_plan_service[:end_date]))
           within = false
@@ -55,6 +58,8 @@ module Pacing
       # filter out services that haven't started or whose time is passed
       school_plan_services = Pacing::Normalizer.new(@school_plan[:school_plan_services], @date).normalize
       services = school_plan_services[:school_plan_services].filter do |school_plan_service|
+        next false unless SUPPORTED_INTERVALS.include?(school_plan_service[:interval])
+
         within = true
         if !(parse_date(school_plan_service[:start_date]) <= parse_date(@date) && parse_date(@date) <= parse_date(school_plan_service[:end_date]))
           within = false

--- a/lib/pacing/version.rb
+++ b/lib/pacing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pacing
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
 end

--- a/spec/pacing_spec.rb
+++ b/spec/pacing_spec.rb
@@ -226,18 +226,7 @@ RSpec.describe Pacing::Pacer do
       non_business_days = ['04-25-2022']
       results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, mode: :liberal).interval
 
-      expect(results).to eq([
-          {
-            discipline: 'Speech Therapy',
-            start_date: nil,
-            reset_date: nil
-          },
-          {
-            discipline: 'Physical Therapy',
-            start_date: nil,
-            reset_date: nil
-          }
-        ])
+      expect(results).to eq([])
     end
   end
 
@@ -5304,5 +5293,92 @@ describe "should calculate pacing correctly when interval starts with 'per month
     non_business_days = []
     results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days, show_frequency: true).calculate
     expect(results).to eq([{:discipline=>"Speech Therapy", :remaining_visits=>26, :used_visits=>4, :pace=>2, :pace_indicator=>"🐇", :pace_suggestion=>"less than once per week", :expected_visits_at_date=>2, :reset_date=>"09-27-2023", :frequency=>"30Yx20ST"}])
+  end
+end
+
+describe "should skip services with unsupported intervals" do
+  it "should return an empty array when all services have unsupported intervals" do
+    school_plan = {
+      school_plan_services: [
+        {
+          school_plan_type: 'IEP',
+          start_date: '04-01-2022',
+          end_date: '04-01-2023',
+          type_of_service: 'Language Therapy',
+          frequency: 6,
+          interval: 'daily',
+          time_per_session_in_minutes: 30,
+          completed_visits_for_current_interval: 7,
+          extra_sessions_allowable: 1,
+          interval_for_extra_sessions_allowable: 'monthly'
+        }
+      ]
+    }
+
+    date = '05-19-2022'
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days).calculate
+    expect(results).to eq([])
+  end
+
+  it "should return an empty array for per reporting period interval" do
+    school_plan = {
+      school_plan_services: [
+        {
+          school_plan_type: 'IEP',
+          start_date: '04-01-2022',
+          end_date: '04-01-2023',
+          type_of_service: 'Speech Therapy',
+          frequency: 6,
+          interval: 'per reporting period',
+          time_per_session_in_minutes: 30,
+          completed_visits_for_current_interval: 3,
+          extra_sessions_allowable: 0,
+          interval_for_extra_sessions_allowable: 'monthly'
+        }
+      ]
+    }
+
+    date = '05-19-2022'
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days).calculate
+    expect(results).to eq([])
+  end
+
+  it "should only return results for services with supported intervals" do
+    school_plan = {
+      school_plan_services: [
+        {
+          school_plan_type: 'IEP',
+          start_date: '04-01-2022',
+          end_date: '04-01-2023',
+          type_of_service: 'Language Therapy',
+          frequency: 6,
+          interval: 'daily',
+          time_per_session_in_minutes: 30,
+          completed_visits_for_current_interval: 7,
+          extra_sessions_allowable: 1,
+          interval_for_extra_sessions_allowable: 'monthly'
+        },
+        {
+          school_plan_type: 'IEP',
+          start_date: '04-01-2022',
+          end_date: '04-01-2023',
+          type_of_service: 'Physical Therapy',
+          frequency: 6,
+          interval: 'monthly',
+          time_per_session_in_minutes: 30,
+          completed_visits_for_current_interval: 2,
+          extra_sessions_allowable: 1,
+          interval_for_extra_sessions_allowable: 'monthly'
+        }
+      ]
+    }
+
+    date = '05-19-2022'
+    non_business_days = []
+    results = Pacing::Pacer.new(school_plan: school_plan, date: date, non_business_days: non_business_days).calculate
+    expect(results.length).to eq(1)
+    expect(results[0][:discipline]).to eq('Physical Therapy')
   end
 end


### PR DESCRIPTION
## Summary

- Services with unsupported intervals (e.g. `"daily"`, `"per reporting period"`) are now filtered out in `calculate` and `interval` instead of crashing with `undefined method '+' for nil`
- Guard added to `Normalizer#normalize_to_monthly_frequency` to prevent division by `nil` when an unrecognized interval isn't in the `interval_average_days` hash
- Version bumped to 2.2.2

## Root Cause

`start_of_treatment_date` and `interval_days` use case statements with no default branch. When an unsupported interval is passed, they return `nil`. Then `end_of_treatment_date` calls `nil + interval_days(interval)` which raises `NoMethodError: undefined method '+' for nil`.

## Changes

| File | Change |
|------|--------|
| `lib/pacing/pacer.rb` | Add `SUPPORTED_INTERVALS` constant; filter unsupported intervals in `calculate` and `interval` |
| `lib/pacing/normalizer.rb` | Guard `normalize_to_monthly_frequency` against dividing by `nil` |
| `lib/pacing/version.rb` | Bump to 2.2.2 |
| `spec/pacing_spec.rb` | Update existing "per reporting period" interval test; add 3 new specs for unsupported intervals |

## Test plan

- [x] All 575 specs pass
- [x] New specs cover: all-unsupported, per-reporting-period only, and mixed supported/unsupported services
- [x] Existing "per reporting period" interval spec updated to expect `[]` instead of nil-filled results

🤖 Generated with [Claude Code](https://claude.com/claude-code)